### PR TITLE
mds/scrub: skip backtrace scrub for inode 0x1

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4684,8 +4684,9 @@ void CInode::validate_disk_state(CInode::validated_data *results,
       if (results->backtrace.ondisk_read_retval != 0) {
         results->backtrace.error_str << "failed to read off disk; see retval";
         // we probably have a new unwritten file!
+        // or backtrace for root inode (inode 0x1) doesn't make sense
         // so skip the backtrace scrub for this entry and say that all's well
-        if (in->is_dirty_parent()) {
+        if (in->is_dirty_parent() || in->ino() == MDS_INO_ROOT) {
           dout(20) << "forcing backtrace as passed since inode is dirty parent" << dendl;
           results->backtrace.passed = true;
         }
@@ -4708,8 +4709,9 @@ void CInode::validate_disk_state(CInode::validated_data *results,
         results->backtrace.error_str << "failed to decode on-disk backtrace ("
                                      << bl.length() << " bytes)!";
         // we probably have a new unwritten file!
+        // or backtrace for root inode (inode 0x1) doesn't make sense
         // so skip the backtrace scrub for this entry and say that all's well
-        if (in->is_dirty_parent()) {
+        if (in->is_dirty_parent() || in->ino() == MDS_INO_ROOT) {
           dout(20) << "decode failed; forcing backtrace as passed since "
                       "inode is dirty parent" << dendl;
           results->backtrace.passed = true;


### PR DESCRIPTION

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
