### PR TITLE
qa: run kernel_untar_build with newer tarball

### DIFF
--- a/qa/workunits/kernel_untar_build.sh
+++ b/qa/workunits/kernel_untar_build.sh
@@ -2,11 +2,13 @@
 
 set -ex
 
-wget -O linux.tar.gz http://download.ceph.com/qa/linux-5.4.tar.gz
+#wget -O linux.tar.gz http://download.ceph.com/qa/linux-5.4.tar.gz
+wget -O linux.tar.xz https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.5.10.tar.xz
 
 mkdir t
 cd t
-tar xzf ../linux.tar.gz
+#tar xzf ../linux.tar.gz
+tar xJf ../linux.tar.xz
 cd linux*
 make defconfig
 make -j`grep -c processor /proc/cpuinfo`


### PR DESCRIPTION
Replace old tarball with url link to linux-6.5.10.tar.xz

Fixes: https://tracker.ceph.com/issues/57655
Signed-off-by: Milind Changire <mchangir@redhat.com>
